### PR TITLE
fix(iceberg): parse response data

### DIFF
--- a/src/iceberg/request-upgrader.service.js
+++ b/src/iceberg/request-upgrader.service.js
@@ -10,6 +10,7 @@
  * @see ApiRequest
  * @private
  */
+import angular from 'angular';
 import cloneDeep from 'lodash/cloneDeep';
 import isArray from 'lodash/isArray';
 import isNull from 'lodash/isNull';
@@ -108,7 +109,7 @@ export default class IcebergRequestUpgrader {
         data,
         headers,
         status,
-      ) => ({ data, headers: headers(), status }),
+      ) => ({ data: angular.fromJson(data), headers: headers(), status }),
     };
 
     merge(action.options,


### PR DESCRIPTION
When going through transformResponse, angular returns raw data and expect user to handle it