### PR TITLE
build(rollup): set output.exports to auto for CJS output

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,11 @@ const outputs = [config.es({
 })];
 
 if (process.env.BUILD === 'production') {
-  outputs.push(config.cjs());
+  outputs.push(config.cjs({
+    output: {
+      exports: 'auto',
+    },
+  }));
   outputs.push(config.umd({
     output: {
       globals: {


### PR DESCRIPTION
## :construction_worker: Build

8f7956c  - build(rollup): set output.exports to auto for CJS output

## :link: Relates

- https://rollupjs.org/guide/en/#outputexports

Closes #55

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>