### PR TITLE
fix: addFilter setFilter parameters

### DIFF
--- a/src/common/request.factory.js
+++ b/src/common/request.factory.js
@@ -118,7 +118,7 @@ export default /* @ngInject */ function (
    * @returns {ApiRequest} new instance
    * @see APIV7_FILTER_COMPARATOR
    */
-  ApiRequest.prototype.setFilter = function (field, comparator, ...reference) {
+  ApiRequest.prototype.setFilter = function (field, comparator, reference) {
     const clone = this.clone();
     if (!field) {
       delete clone.apiOptions.filters;
@@ -129,7 +129,7 @@ export default /* @ngInject */ function (
       {
         field,
         comparator,
-        reference: angular.isArray(reference) ? reference.join(',') : reference,
+        reference,
       },
     ];
     return clone;
@@ -150,7 +150,7 @@ export default /* @ngInject */ function (
    * @returns {ApiRequest} new instance
    * @see APIV7_FILTER_COMPARATOR
    */
-  ApiRequest.prototype.addFilter = function (field, comparator, ...reference) {
+  ApiRequest.prototype.addFilter = function (field, comparator, reference) {
     const clone = this.clone();
     clone.apiOptions.filters = clone.apiOptions.filters || [];
     clone.apiOptions.filters.push({

--- a/src/iceberg/request-upgrader.service.js
+++ b/src/iceberg/request-upgrader.service.js
@@ -59,7 +59,7 @@ export default class IcebergRequestUpgrader {
       return {
         'X-Pagination-Filter':
           filters
-            .map(({ field, comparator, reference }) => `${field}:${comparator}=${reference.map((ref) => encodeURIComponent(ref)).join(',')}`)
+            .map(({ field, comparator, reference }) => `${field}:${comparator}=${[].concat(reference).map((ref) => encodeURIComponent(ref)).join(',')}`)
             .join('&'),
       };
     }


### PR DESCRIPTION
previous behavior :
```js
// calling :
addFilter('foo', 'in', [1, 2]);

// results in :
apiOptions.filters = {
  field: 'foo',
  comparator: 'in',
  reference: [ // this is wrong !!!
    [1, 2],
  ],
};
```
notice that the reference parameter is wrong because we have ```...reference``` in the method declaration ```function (field, comparator, ...reference)``` and thus we get a nested array