### PR TITLE
feat(iceberg): support of apiv2

### DIFF
--- a/src/common/request.factory.js
+++ b/src/common/request.factory.js
@@ -34,6 +34,7 @@ export default /* @ngInject */ function (
     this.options = resourceOptions;
     this.apiOptions = apiOptions || {};
     this.serviceType = serviceType;
+    this.apiVersion = 'apiv6';
 
     this.requestManagers = {
       apiIcebergRequestUpgrader,
@@ -44,6 +45,12 @@ export default /* @ngInject */ function (
     }
     return this;
   }
+
+  ApiRequest.prototype.setApiVersion = function (apiVersion) {
+    const clone = this.clone();
+    clone.apiOptions.apiVersion = angular.isDefined(apiVersion) ? apiVersion : 'apiv6';
+    return clone;
+  };
 
   /**
    * @ngdoc method

--- a/src/common/request.factory.js
+++ b/src/common/request.factory.js
@@ -48,7 +48,7 @@ export default /* @ngInject */ function (
 
   ApiRequest.prototype.setApiVersion = function (apiVersion) {
     const clone = this.clone();
-    clone.apiOptions.apiVersion = angular.isDefined(apiVersion) ? apiVersion : 'apiv6';
+    clone.apiOptions.apiVersion = angular.isString(apiVersion) ? apiVersion : 'apiv6';
     return clone;
   };
 

--- a/src/iceberg/request-upgrader.service.js
+++ b/src/iceberg/request-upgrader.service.js
@@ -119,7 +119,7 @@ export default class IcebergRequestUpgrader {
       action.options.transformResponse ? {} : defaultOptions,
       {
         headers: IcebergRequestUpgrader.buildHeaders(apiOptions, cleanCache),
-        serviceType: 'apiv6',
+        serviceType: apiOptions.apiVersion || 'apiv6',
       });
     return action;
   }


### PR DESCRIPTION
# Description

Enable the use of apiv2 with iceberg wrapper.

## Usage

With the `setApiVersion` method, you can specify the api version you wish (`apiv6` by default or `apiv2`).

For example: 

```js
let request = iceberg('/dedicated/server')
  .query()
  .setApiVersion('apiv2')
  .expand('CachedObjectList-Pages')
  .limit(100)
  .offset(0)
  .sort('serviceName', 'ASC');
```

## Reference
- DTCORE-511